### PR TITLE
Fix TempData Implementation

### DIFF
--- a/src/Giraffe.Razor/HttpHandlers.fs
+++ b/src/Giraffe.Razor/HttpHandlers.fs
@@ -1,4 +1,5 @@
 namespace Giraffe.Razor
+open Microsoft.AspNetCore.Mvc.ViewFeatures
 
 [<AutoOpen>]
 module HttpHandlers =
@@ -26,8 +27,8 @@ module HttpHandlers =
         fun (next : HttpFunc) (ctx : HttpContext) ->
             task {
                 let engine = ctx.RequestServices.GetService<IRazorViewEngine>()
-                let tempDataProvider = ctx.RequestServices.GetService<ITempDataProvider>()
-                let! result = renderView engine tempDataProvider ctx viewName model viewData modelState
+                let tempDataDict = ctx.RequestServices.GetService<ITempDataDictionaryFactory>().GetTempData ctx
+                let! result = renderView engine tempDataDict ctx viewName model viewData modelState
                 match result with
                 | Error msg -> return (failwith msg)
                 | Ok output ->

--- a/src/Giraffe.Razor/RazorEngine.fs
+++ b/src/Giraffe.Razor/RazorEngine.fs
@@ -44,7 +44,7 @@ module RazorEngine =
         routeData
 
     let renderView (razorViewEngine   : IRazorViewEngine)
-                   (tempDataProvider  : ITempDataProvider)
+                   (tempDataDict      : ITempDataDictionary)
                    (httpContext       : HttpContext)
                    (viewName          : string)
                    (model             : 'T option)
@@ -73,10 +73,10 @@ module RazorEngine =
                 if (viewData.IsSome) then
                     viewData.Value
                     |> Seq.iter (fun x -> viewDataDict.Add x)
-                let tempDataDict       = TempDataDictionary(actionContext.HttpContext, tempDataProvider)
                 let htmlHelperOptions  = HtmlHelperOptions()
                 use output = new StringWriter()
                 let viewContext = ViewContext(actionContext, view, viewDataDict, tempDataDict, output, htmlHelperOptions)
                 do! view.RenderAsync(viewContext)
+                tempDataDict.Save()
                 return Ok (output.ToString())
         }


### PR DESCRIPTION
- Modify handlers and engine to use TempDataDictionary provided by the factory rather than creating a new TempDataDictionary when passing to view engine
- Save TempDataDictionary after view is rendered in order to persist newly created data as well as remove items which have been viewed
Fixes #12