### PR TITLE
Add IModelMetadataProvider to RazorEngine

### DIFF
--- a/src/Giraffe.Razor/HttpHandlers.fs
+++ b/src/Giraffe.Razor/HttpHandlers.fs
@@ -25,9 +25,10 @@ module HttpHandlers =
                   (modelState  : ModelStateDictionary option) : HttpHandler =
         fun (next : HttpFunc) (ctx : HttpContext) ->
             task {
+                let metadataProvider = ctx.RequestServices.GetService<IModelMetadataProvider>()
                 let engine = ctx.RequestServices.GetService<IRazorViewEngine>()
                 let tempDataDict = ctx.RequestServices.GetService<ITempDataDictionaryFactory>().GetTempData ctx
-                let! result = renderView engine tempDataDict ctx viewName model viewData modelState
+                let! result = renderView engine metadataProvider tempDataDict ctx viewName model viewData modelState
                 match result with
                 | Error msg -> return (failwith msg)
                 | Ok output ->

--- a/src/Giraffe.Razor/RazorEngine.fs
+++ b/src/Giraffe.Razor/RazorEngine.fs
@@ -44,6 +44,7 @@ module RazorEngine =
         routeData
 
     let renderView (razorViewEngine   : IRazorViewEngine)
+                   (modelMetadataProvider: IModelMetadataProvider)
                    (tempDataDict      : ITempDataDictionary)
                    (httpContext       : HttpContext)
                    (viewName          : string)
@@ -67,7 +68,7 @@ module RazorEngine =
                 let viewModelState = defaultArg modelState (ModelStateDictionary())
                 let viewDataDict =
                     ViewDataDictionary<'T>(
-                        EmptyModelMetadataProvider(),
+                        modelMetadataProvider,
                         viewModelState,
                         Model = viewModel)
                 if (viewData.IsSome) then


### PR DESCRIPTION
We were trying to use ModelMetadata in Views (e.g. the `Placeholder` populated by a `DisplayAttribute` `Prompt`) and it failed because the Metadata was not supplied to the ViewData.

I don't know if using the `EmptyModelMetadataProvider`  was done on purpose but using  `IModelMetadataProvider` would solve the issue 