### PR TITLE
Update to ASP.NET Core 3.1 [continued]

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,12 @@
 version: 0.1.0-{build}
 image:
-  - Visual Studio 2017
+  - Visual Studio 2019
   - Ubuntu
 environment:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
 init:
   - git config --global core.autocrlf true
 install:
-  - sh: export FrameworkPathOverride=$(dirname $(which mono))/../lib/mono/4.5/
   - ps: .\.psscripts\install-dotnet.ps1
 build: off
 build_script:

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "projects": [ "src", "tests" ],
   "sdk": {
-    "version": "2.2.105"
+    "version": "3.1.100"
   }
 }

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "projects": [ "src", "tests" ],
   "sdk": {
-    "version": "3.1.100"
+    "version": "3.1.100",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
   }
 }

--- a/samples/GiraffeRazorSample/GiraffeRazorSample.fsproj
+++ b/samples/GiraffeRazorSample/GiraffeRazorSample.fsproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>GiraffeRazorSample</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -9,10 +9,6 @@
     <EnableDefaultContentItems>false</EnableDefaultContentItems>
     <RunWorkingDirectory>$(MSBuildThisFileDirectory)</RunWorkingDirectory>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Giraffe.Razor\Giraffe.Razor.fsproj" />

--- a/samples/GiraffeRazorSample/Program.fs
+++ b/samples/GiraffeRazorSample/Program.fs
@@ -37,7 +37,7 @@ type CreatePerson =
 // ---------------------------------
 
 let antiforgeryTokenHandler =
-    text "Bad antiforgery token" 
+    text "Bad antiforgery token"
     |> RequestErrors.badRequest
     |> validateAntiforgeryToken
 
@@ -146,7 +146,8 @@ let configureApp (app : IApplicationBuilder) =
 
 let configureServices (services : IServiceCollection) =
     let sp  = services.BuildServiceProvider()
-    let env = sp.GetService<IHostingEnvironment>()
+    let env = sp.GetService<IWebHostEnvironment>()
+    services.AddGiraffe() |> ignore
     Path.Combine(env.ContentRootPath, "Views")
     |> services.AddRazorEngine
     |> ignore

--- a/src/Giraffe.Razor/Giraffe.Razor.fsproj
+++ b/src/Giraffe.Razor/Giraffe.Razor.fsproj
@@ -9,7 +9,7 @@
     <NeutralLanguage>en-GB</NeutralLanguage>
 
     <!-- Build settings -->
-    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -35,14 +35,9 @@
     <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
-    <PackageReference Include="Giraffe" Version="4.0.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+  <ItemGroup>
+    <PackageReference Include="Giraffe" Version="4.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
-    <PackageReference Include="Giraffe" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Giraffe.Razor/Giraffe.Razor.fsproj
+++ b/src/Giraffe.Razor/Giraffe.Razor.fsproj
@@ -9,7 +9,7 @@
     <NeutralLanguage>en-GB</NeutralLanguage>
 
     <!-- Build settings -->
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461;netcoreapp3.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Library</OutputType>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -35,14 +35,14 @@
     <NoWarn>FS2003</NoWarn>
   </PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.*" />
-    <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="2.2.*" />
-    <PackageReference Include="Microsoft.Extensions.Primitives" Version="2.2.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Antiforgery" Version="2.2.*" />
-    <PackageReference Include="TaskBuilder.fs" Version="2.1.*" />
-    <PackageReference Include="Giraffe" Version="3.6.*" />
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Giraffe" Version="4.0.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.0" />
+    <PackageReference Include="Giraffe" Version="4.0.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Giraffe.Razor/Middleware.fs
+++ b/src/Giraffe.Razor/Middleware.fs
@@ -3,34 +3,19 @@ namespace Giraffe.Razor
 [<AutoOpen>]
 module Middleware =
 
-#if NETCOREAPP3_1
     open Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
-#else
-    open Microsoft.AspNetCore.Mvc.Razor
-#endif
     open Microsoft.Extensions.DependencyInjection
     open Microsoft.Extensions.FileProviders
 
     type IServiceCollection with
 
         member this.AddRazorEngine(viewsFolderPath: string) =
-#if NETCOREAPP3_1
             this.Configure<MvcRazorRuntimeCompilationOptions>(fun (options: MvcRazorRuntimeCompilationOptions) ->
                 options.FileProviders.Clear()
                 options.FileProviders.Add(new PhysicalFileProvider(viewsFolderPath))).AddMvc().AddRazorRuntimeCompilation()
             |> ignore
-#else
-            this.Configure<RazorViewEngineOptions>(fun (options : RazorViewEngineOptions) ->
-                    options.FileProviders.Clear()
-                    options.FileProviders.Add(new PhysicalFileProvider(viewsFolderPath))).AddMvc()
-            |> ignore
-#endif
             this.AddAntiforgery()
 
         member this.AddRazorEngine() =
-#if NETCOREAPP3_1
             this.AddMvc().AddRazorRuntimeCompilation() |> ignore
-#else
-            this.AddMvc() |> ignore
-#endif
             this.AddAntiforgery()

--- a/src/Giraffe.Razor/Middleware.fs
+++ b/src/Giraffe.Razor/Middleware.fs
@@ -3,20 +3,34 @@ namespace Giraffe.Razor
 [<AutoOpen>]
 module Middleware =
 
+#if NETCOREAPP3_1
+    open Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation
+#else
     open Microsoft.AspNetCore.Mvc.Razor
+#endif
     open Microsoft.Extensions.DependencyInjection
     open Microsoft.Extensions.FileProviders
 
     type IServiceCollection with
-        member this.AddRazorEngine (viewsFolderPath : string) =
-            this.Configure<RazorViewEngineOptions>(
-                fun (options : RazorViewEngineOptions) ->
-                    options.FileProviders.Clear()
-                    options.FileProviders.Add(new PhysicalFileProvider(viewsFolderPath)))
-                .AddMvc()
+
+        member this.AddRazorEngine(viewsFolderPath: string) =
+#if NETCOREAPP3_1
+            this.Configure<MvcRazorRuntimeCompilationOptions>(fun (options: MvcRazorRuntimeCompilationOptions) ->
+                options.FileProviders.Clear()
+                options.FileProviders.Add(new PhysicalFileProvider(viewsFolderPath))).AddMvc().AddRazorRuntimeCompilation()
             |> ignore
+#else
+            this.Configure<RazorViewEngineOptions>(fun (options : RazorViewEngineOptions) ->
+                    options.FileProviders.Clear()
+                    options.FileProviders.Add(new PhysicalFileProvider(viewsFolderPath))).AddMvc()
+            |> ignore
+#endif
             this.AddAntiforgery()
 
         member this.AddRazorEngine() =
+#if NETCOREAPP3_1
+            this.AddMvc().AddRazorRuntimeCompilation() |> ignore
+#else
             this.AddMvc() |> ignore
+#endif
             this.AddAntiforgery()


### PR DESCRIPTION
Continuation of #14 

Sorry to have messed you about @JonCanning, enough time has passed since your PR was initially opened that it now makes sense to just target `netcoreapp3.1`, as you had done originally.

I've given up on compile-time compilation as well, as it's not as simple as I first expected.